### PR TITLE
updates for recent python and matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     - python3-matplotlib
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install python$PYTHON_VER homebrew/science/matplotlib; fi
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install python$PYTHON_VER; brew install homebrew/science/matplotlib; fi
 
 script:
   - MATPLOTLIB_D_PYTHON=python$PYTHON_VER dub test --compiler=${DC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 os:
   - linux
   - osx
@@ -5,13 +7,24 @@ os:
 language: d
 
 d:
-  - ldc2
+  - ldc
   - dmd
 
-before_install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install python-tk; fi
-  - sudo pip install matplotlib
+env:
+  - PYTHON_VER=2
+  - PYTHON_VER=3
 
+addons:
+  apt:
+    packages:
+    - python-tk
+    - python3-tk
+    - python-pip
+    - python3-pip
+
+before_install:
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install python$PYTHON_VER; fi
+  - pip$PYTHON_VER install matplotlib --user
 
 script:
-  - dub test --compiler=${DC}
+  - MATPLOTLIB_D_PYTHON=python$PYTHON_VER dub test --compiler=${DC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,11 @@ addons:
     packages:
     - python-tk
     - python3-tk
-    - python-pip
-    - python3-pip
+    - python-matplotlib
+    - python3-matplotlib
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install python$PYTHON_VER; fi
-  - pip$PYTHON_VER install matplotlib --user
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install python$PYTHON_VER homebrew/science/matplotlib; fi
 
 script:
   - MATPLOTLIB_D_PYTHON=python$PYTHON_VER dub test --compiler=${DC}

--- a/dub.json
+++ b/dub.json
@@ -8,5 +8,5 @@
     "targetType": "staticLibrary",
     "targetPath": "build",
     "workingDirectory": "build",
-    "preBuildCommands": ["python $PACKAGE_DIR/python/prebuild.py $PACKAGE_DIR"]
+    "preBuildCommands": ["$MATPLOTLIB_D_PYTHON $PACKAGE_DIR/python/prebuild.py $PACKAGE_DIR"]
 }

--- a/python/prebuild.py
+++ b/python/prebuild.py
@@ -23,9 +23,9 @@ def gen_pyplot_functions(dub_root):
     generate 'pyplot_functions.txt' for matplotlibd.pyplot.
     '''
     import matplotlib.pyplot
-    from string import lowercase
+    from string import ascii_lowercase
 
-    functions = filter(lambda i: i[0] != '_' or i[0] in lowercase,
+    functions = filter(lambda i: i[0] != '_' or i[0] in ascii_lowercase,
                        extract_function_names(matplotlib.pyplot))
 
     with open(dub_root + "/views/pyplot_functions.txt", "w") as f:

--- a/source/matplotlibd/pyplot.d
+++ b/source/matplotlibd/pyplot.d
@@ -8,8 +8,12 @@ string py_script = "import matplotlib.pyplot as plt\n";
 
 immutable string plt_funcs = (){
     import std.string: splitLines;
+    import std.meta : staticMap, aliasSeqOf;
 
-    string[] method_names = import("pyplot_functions.txt").splitLines;
+    enum isValidIdentifier(string s) = __traits(compiles, { mixin(`auto ` ~ s ~ ` = 3;` ); });
+    enum fixIdentifier(string s) = isValidIdentifier!s ? s : s ~ '_';
+    auto method_names = staticMap!(fixIdentifier, aliasSeqOf!(import("pyplot_functions.txt").splitLines));
+
     string plt_funcs;
 
     foreach(name; method_names) {

--- a/views/pyplot_functions.txt
+++ b/views/pyplot_functions.txt
@@ -36,15 +36,6 @@ SubplotTool
 Text
 TickHelper
 Widget
-_auto_draw_if_interactive
-_autogen_docstring
-_backend_selection
-_imread
-_imsave
-_setp
-_setup_pyplot_info_docstrings
-_show
-_string_to_bool
 acorr
 angle_spectrum
 annotate
@@ -82,6 +73,7 @@ csd
 cycler
 dedent
 delaxes
+deprecated
 disconnect
 draw
 draw_all
@@ -145,6 +137,7 @@ matshow
 minorticks_off
 minorticks_on
 new_figure_manager
+nipy_spectral
 over
 pause
 pcolor


### PR DESCRIPTION
Changes

* Use an environment variable (`MATPLOTLIB_D_PYTHON`) instead of whatever `python` happens to be.
* python3 doesn't support `lowercase` from `string`, so use `ascii_lowercase` instead (matplotlib functions are all ascii anyway)
* recent matplotlib has a function called `deprecated`, which is a D keyword. By testing for invalid identifiers and appending an `_` to them, we avoid this problem and any other similar ones that may come along.